### PR TITLE
Use marker interface pattern for Command and Query instead of abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ use App\ValueObject\UserId;
 use Assert\Assertion;
 use DigitalCraftsman\CQRS\Command\Command;
 
-final class CreateNewsArticleCommand extends Command
+final class CreateNewsArticleCommand implements Command
 {
     public function __construct(
         public UserId $userId,

--- a/docs/dto-constructor.md
+++ b/docs/dto-constructor.md
@@ -57,7 +57,7 @@ It transforms an array like the following:
 Into a DTO like this:
 
 ```php
-final class CreateUserAccountCommand extends Command
+final class CreateUserAccountCommand implements Command
 {
     public function __construct(
         public UserId $userId,

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 namespace DigitalCraftsman\CQRS\Command;
 
 /** @psalm-immutable */
-abstract class Command
+interface Command
 {
 }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 namespace DigitalCraftsman\CQRS\Query;
 
 /** @psalm-immutable */
-abstract class Query
+interface Query
 {
 }

--- a/src/Workflow/Workflow.php
+++ b/src/Workflow/Workflow.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 namespace DigitalCraftsman\CQRS\Workflow;
 
 /** @psalm-immutable */
-abstract class Workflow
+interface Workflow
 {
 }

--- a/tests/DTOConstructor/Command/CreateNewsArticleCommand.php
+++ b/tests/DTOConstructor/Command/CreateNewsArticleCommand.php
@@ -7,7 +7,7 @@ namespace DigitalCraftsman\CQRS\DTOConstructor\Command;
 use DigitalCraftsman\CQRS\Command\Command;
 
 /** @psalm-immutable */
-final class CreateNewsArticleCommand extends Command
+final class CreateNewsArticleCommand implements Command
 {
     public function __construct(
        public string $userId,


### PR DESCRIPTION
- [x] Replace abstract Command, Query and Workflow classes by interfaces
- [x] Update docs that identify them as abstract classes