### PR TITLE
Use options instead of defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,13 @@ $routes->add(
 )
     ->controller([CommandController::class, 'handle'])
     ->methods([Request::METHOD_POST])
-    ->defaults([
-        'routePayload' => Configuration::routePayload(
-            dtoClass: CreateNewsArticleCommand::class,
-            handlerClass: CreateNewsArticleCommandHandler::class,
-            dtoValidatorClasses: [
-                UserIdValidator::class,
-            ],
-        ),
-    ]);
+    ->options(RouteConfiguration::routeOptions(
+        dtoClass: CreateNewsArticleCommand::class,
+        handlerClass: CreateNewsArticleCommandHandler::class,
+        dtoValidatorClasses: [
+            UserIdValidator::class,
+        ],
+    ));
 ```
 
 You only need to define the components that differ from the defaults configured in the `cqrs.yaml` configuration. Read more about [routing here](./docs/routing.md).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,45 @@
 # Upgrade guide
 
+## From 0.5.* to 0.6.0
+
+**Route configuration uses options**
+
+Previously the route configuration was configured using the `defaults()` method of the route. But this was kind of hack to transport the information to the controller. The defaults aren't really meant to be used for configuration. A more appropriate way is using the `options()` method. And that's what was introduced in 0.6.0 including a few other class and method name changes.
+
+Relevant for updating to the new version: `Configuration` was renamed to `RouteConfiguration` and the method `routePayload` was renamed to `routeOptions`.
+
+Before:
+
+```php
+$routes->add(
+    'api_blog_create_blog_article_command',
+    '/api/blog/create-blog-article-command',
+)
+    ->controller([CommandController::class, 'handle'])
+    ->methods([Request::METHOD_POST])
+    ->defaults([
+        'routePayload' => Configuration::routePayload(
+            dtoClass: CreateBlogArticleCommand::class,
+            handlerClass: CreateBlogArticleCommandHandler::class,
+        ),
+    ]);
+```
+
+After:
+
+```php
+$routes->add(
+    'api_blog_create_blog_article_command',
+    '/api/blog/create-blog-article-command',
+)
+    ->controller([CommandController::class, 'handle'])
+    ->methods([Request::METHOD_POST])
+    ->options(RouteConfiguration::routeOptions(
+        dtoClass: CreateBlogArticleCommand::class,
+        handlerClass: CreateBlogArticleCommandHandler::class,
+    ));
+```
+
 ## From 0.4.* to 0.5.0
 
 **Changes to the `DTOConstructorInterface`**

--- a/docs/handler-wrapper.md
+++ b/docs/handler-wrapper.md
@@ -162,7 +162,7 @@ The priority of the `catch` method is set to a low value like `-100` to make sur
 Handler wrappers in a route are not defined like other components with just the class names, but instead as `HandlerWrapperConfiguration`. They still contain the class of the implementation but additionally can define parameters that can be used in the handler wrapper.
 
 ```php
-'routePayload' => Configuration::routePayload(
+RouteConfiguration::routeOptions(
     handlerWrapperConfigurations: [
         new HandlerWrapperConfiguration(
             handlerWrapperClass: SilentExceptionWrapper::class,

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -11,16 +11,14 @@ $routes->add(
 )
     ->controller([CommandController::class, 'handle'])
     ->methods([Request::METHOD_POST])
-    ->defaults([
-        'routePayload' => Configuration::routePayload(
-            dtoClass: CreateProductNewsArticleCommand::class,
-            handlerClass: CreateProductNewsArticleCommandHandler::class,
-            requestDecoderClass: CommandWithFilesRequestDecoder::class,
-            dtoValidatorClasses: [
-                UserIdValidator::class,
-            ],
-        ),
-    ]);
+    ->options(RouteConfiguration::routeOptions(
+        dtoClass: CreateProductNewsArticleCommand::class,
+        handlerClass: CreateProductNewsArticleCommandHandler::class,
+        requestDecoderClass: CommandWithFilesRequestDecoder::class,
+        dtoValidatorClasses: [
+            UserIdValidator::class,
+        ],
+    ));
 ```
 
 All parameters except `dtoClass` and `handlerClass` are optional. You might only need to define those when you only need the default components for the other parameters ([configured in the `cqrs.yaml`](./configuration.md)).
@@ -41,7 +39,7 @@ cqrs:
 And you then adapt it like this:
 
 ```php
-'routePayload' => Configuration::routePayload(
+RouteConfiguration::routeOptions(
     dtoValidatorClasses: [
         FilesizeValidator::class,
     ],
@@ -53,7 +51,7 @@ The end result is that only the `FilesizeValidator` is left. You need to include
 This way you're also able to remove all default DTO validators from a route like this:
 
 ```php
-'routePayload' => Configuration::routePayload(
+RouteConfiguration::routeOptions(
     dtoValidatorClasses: [],
 ),
 ```

--- a/src/DTO/HandlerWrapperConfiguration.php
+++ b/src/DTO/HandlerWrapperConfiguration.php
@@ -25,7 +25,7 @@ final class HandlerWrapperConfiguration
      *   parameters: array<int, string|int|float|bool>|string|int|float|bool|null,
      * }
      */
-    public function toRoutePayload(): array
+    public function toRouteOptions(): array
     {
         return [
             'handlerWrapperClass' => $this->handlerWrapperClass,
@@ -39,7 +39,7 @@ final class HandlerWrapperConfiguration
      *   parameters: array<int, string|int|float|bool>|string|int|float|bool|null,
      * } $routingConfiguration
      */
-    public static function fromRoutePayload(array $routingConfiguration): self
+    public static function fromRouteOptions(array $routingConfiguration): self
     {
         return new self(
             $routingConfiguration['handlerWrapperClass'],

--- a/src/DTO/RouteConfiguration.php
+++ b/src/DTO/RouteConfiguration.php
@@ -21,7 +21,7 @@ use DigitalCraftsman\CQRS\ResponseConstructor\ResponseConstructorInterface;
  *
  * @codeCoverageIgnore
  */
-final class Configuration
+final class RouteConfiguration
 {
     /**
      * @psalm-param class-string<Command>|class-string<Query> $dtoClass
@@ -55,7 +55,7 @@ final class Configuration
      * @psalm-param array<int, HandlerWrapperConfiguration>|null $handlerWrapperConfigurations
      * @psalm-param class-string<ResponseConstructorInterface>|null $responseConstructorClass
      */
-    public static function routePayload(
+    public static function routeOptions(
         string $dtoClass,
         string $handlerClass,
         ?string $requestDecoderClass = null,
@@ -76,7 +76,7 @@ final class Configuration
             $responseConstructorClass,
         );
 
-        return $configuration->toRoutePayload();
+        return $configuration->toRouteOptions();
     }
 
     /**
@@ -94,10 +94,10 @@ final class Configuration
      *   responseConstructorClass: class-string<ResponseConstructorInterface>|null,
      * } $routePayload
      */
-    public static function fromRoutePayload(array $routePayload): self
+    public static function fromRouteOptions(array $routeOptions): self
     {
         $handlerWrapperConfigurations = null;
-        if ($routePayload['handlerWrapperConfigurations'] !== null) {
+        if ($routeOptions['handlerWrapperConfigurations'] !== null) {
             $handlerWrapperConfigurations = array_map(
                 /**
                  * @psalm-param array{
@@ -105,20 +105,20 @@ final class Configuration
                  *   parameters: array<int, string|int|float|bool>|string|int|float|bool|null,
                  * } $handlerWrapperRoutePayload
                  */
-                static fn (array $handlerWrapperRoutePayload) => HandlerWrapperConfiguration::fromRoutePayload($handlerWrapperRoutePayload),
-                $routePayload['handlerWrapperConfigurations'],
+                static fn (array $handlerWrapperRoutePayload) => HandlerWrapperConfiguration::fromRouteOptions($handlerWrapperRoutePayload),
+                $routeOptions['handlerWrapperConfigurations'],
             );
         }
 
         return new self(
-            $routePayload['dtoClass'],
-            $routePayload['handlerClass'],
-            $routePayload['requestDecoderClass'],
-            $routePayload['dtoDataTransformerClasses'],
-            $routePayload['dtoConstructorClass'],
-            $routePayload['dtoValidatorClasses'],
+            $routeOptions['dtoClass'],
+            $routeOptions['handlerClass'],
+            $routeOptions['requestDecoderClass'],
+            $routeOptions['dtoDataTransformerClasses'],
+            $routeOptions['dtoConstructorClass'],
+            $routeOptions['dtoValidatorClasses'],
             $handlerWrapperConfigurations,
-            $routePayload['responseConstructorClass'],
+            $routeOptions['responseConstructorClass'],
         );
     }
 
@@ -137,7 +137,7 @@ final class Configuration
      *   responseConstructorClass: class-string<ResponseConstructorInterface>|null,
      * }
      */
-    private function toRoutePayload(): array
+    private function toRouteOptions(): array
     {
         return [
             'dtoClass' => $this->dtoClass,
@@ -148,7 +148,7 @@ final class Configuration
             'dtoValidatorClasses' => $this->dtoValidatorClasses,
             'handlerWrapperConfigurations' => $this->handlerWrapperConfigurations !== null
                 ? array_map(
-                    static fn (HandlerWrapperConfiguration $handlerWrapperConfiguration) => $handlerWrapperConfiguration->toRoutePayload(),
+                    static fn (HandlerWrapperConfiguration $handlerWrapperConfiguration) => $handlerWrapperConfiguration->toRouteOptions(),
                     $this->handlerWrapperConfigurations,
                 )
                 : null,

--- a/src/HandlerWrapper/DTO/HandlerWrapperStep.php
+++ b/src/HandlerWrapper/DTO/HandlerWrapperStep.php
@@ -15,6 +15,7 @@ use DigitalCraftsman\CQRS\HandlerWrapper\HandlerWrapperInterface;
  * steps. After this the controller is able to simply select a step and get all relevant wrappers in the correct order.
  *
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class HandlerWrapperStep

--- a/src/HandlerWrapper/DTO/HandlerWrapperWithParameters.php
+++ b/src/HandlerWrapper/DTO/HandlerWrapperWithParameters.php
@@ -8,6 +8,7 @@ use DigitalCraftsman\CQRS\HandlerWrapper\HandlerWrapperInterface;
 
 /**
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class HandlerWrapperWithParameters

--- a/src/ServiceMap/Exception/ConfiguredCommandHandlerNotAvailable.php
+++ b/src/ServiceMap/Exception/ConfiguredCommandHandlerNotAvailable.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ConfiguredCommandHandlerNotAvailable extends \DomainException

--- a/src/ServiceMap/Exception/ConfiguredDTOConstructorNotAvailable.php
+++ b/src/ServiceMap/Exception/ConfiguredDTOConstructorNotAvailable.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ConfiguredDTOConstructorNotAvailable extends \DomainException

--- a/src/ServiceMap/Exception/ConfiguredDTODataTransformerNotAvailable.php
+++ b/src/ServiceMap/Exception/ConfiguredDTODataTransformerNotAvailable.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ConfiguredDTODataTransformerNotAvailable extends \DomainException

--- a/src/ServiceMap/Exception/ConfiguredDTOValidatorNotAvailable.php
+++ b/src/ServiceMap/Exception/ConfiguredDTOValidatorNotAvailable.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ConfiguredDTOValidatorNotAvailable extends \DomainException

--- a/src/ServiceMap/Exception/ConfiguredHandlerWrapperNotAvailable.php
+++ b/src/ServiceMap/Exception/ConfiguredHandlerWrapperNotAvailable.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ConfiguredHandlerWrapperNotAvailable extends \DomainException

--- a/src/ServiceMap/Exception/ConfiguredQueryHandlerNotAvailable.php
+++ b/src/ServiceMap/Exception/ConfiguredQueryHandlerNotAvailable.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ConfiguredQueryHandlerNotAvailable extends \DomainException

--- a/src/ServiceMap/Exception/ConfiguredRequestDecoderNotAvailable.php
+++ b/src/ServiceMap/Exception/ConfiguredRequestDecoderNotAvailable.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ConfiguredRequestDecoderNotAvailable extends \DomainException

--- a/src/ServiceMap/Exception/ConfiguredResponseConstructorNotAvailable.php
+++ b/src/ServiceMap/Exception/ConfiguredResponseConstructorNotAvailable.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ConfiguredResponseConstructorNotAvailable extends \DomainException

--- a/src/ServiceMap/Exception/DTOConstructorOrDefaultDTOConstructorMustBeConfigured.php
+++ b/src/ServiceMap/Exception/DTOConstructorOrDefaultDTOConstructorMustBeConfigured.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class DTOConstructorOrDefaultDTOConstructorMustBeConfigured extends \DomainException

--- a/src/ServiceMap/Exception/RequestDecoderOrDefaultRequestDecoderMustBeConfigured.php
+++ b/src/ServiceMap/Exception/RequestDecoderOrDefaultRequestDecoderMustBeConfigured.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class RequestDecoderOrDefaultRequestDecoderMustBeConfigured extends \DomainException

--- a/src/ServiceMap/Exception/ResponseConstructorOrDefaultResponseConstructorMustBeConfigured.php
+++ b/src/ServiceMap/Exception/ResponseConstructorOrDefaultResponseConstructorMustBeConfigured.php
@@ -7,6 +7,7 @@ namespace DigitalCraftsman\CQRS\ServiceMap\Exception;
 /**
  * @psalm-immutable
  * @codeCoverageIgnore
+ *
  * @internal
  */
 final class ResponseConstructorOrDefaultResponseConstructorMustBeConfigured extends \DomainException

--- a/tests/Controller/CommandControllerTest.php
+++ b/tests/Controller/CommandControllerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\CQRS\Controller;
 
-use DigitalCraftsman\CQRS\DTO\Configuration;
 use DigitalCraftsman\CQRS\DTO\HandlerWrapperConfiguration;
+use DigitalCraftsman\CQRS\DTO\RouteConfiguration;
 use DigitalCraftsman\CQRS\DTOConstructor\SerializerDTOConstructor;
 use DigitalCraftsman\CQRS\RequestDecoder\JsonRequestDecoder;
 use DigitalCraftsman\CQRS\ResponseConstructor\EmptyJsonResponseConstructor;
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -104,7 +105,7 @@ final class CommandControllerTest extends TestCase
         ];
 
         $request = new Request(content: json_encode($content, JSON_THROW_ON_ERROR));
-        $routePayload = Configuration::routePayload(
+        $routeOptions = RouteConfiguration::routeOptions(
             dtoClass: CreateNewsArticleCommand::class,
             handlerClass: CreateNewsArticleCommandHandler::class,
             dtoDataTransformerClasses: [
@@ -118,8 +119,13 @@ final class CommandControllerTest extends TestCase
             ],
         );
 
+        $route = new Route(
+            path: '/api/news-articles/create-news-article-command',
+            options: $routeOptions,
+        );
+
         // -- Act
-        $controller->handle($request, $routePayload);
+        $controller->handle($request, $route);
 
         // -- Assert
         self::assertCount(1, $newsArticleInMemoryRepository->newsArticles);
@@ -183,7 +189,7 @@ final class CommandControllerTest extends TestCase
         ];
 
         $request = new Request(content: json_encode($content, JSON_THROW_ON_ERROR));
-        $routePayload = Configuration::routePayload(
+        $routeOptions = RouteConfiguration::routeOptions(
             dtoClass: CreateNewsArticleCommand::class,
             handlerClass: FailingCreateNewsArticleCommandHandler::class,
             handlerWrapperConfigurations: [
@@ -194,8 +200,13 @@ final class CommandControllerTest extends TestCase
             ],
         );
 
+        $route = new Route(
+            path: '/api/news-articles/create-news-article-command',
+            options: $routeOptions,
+        );
+
         // -- Act
-        $response = $controller->handle($request, $routePayload);
+        $response = $controller->handle($request, $route);
 
         // -- Assert
         self::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
@@ -261,7 +272,7 @@ final class CommandControllerTest extends TestCase
         ];
 
         $request = new Request(content: json_encode($content, JSON_THROW_ON_ERROR));
-        $routePayload = Configuration::routePayload(
+        $routeOptions = RouteConfiguration::routeOptions(
             dtoClass: CreateNewsArticleCommand::class,
             handlerClass: FailingCreateNewsArticleCommandHandler::class,
             handlerWrapperConfigurations: [
@@ -269,7 +280,12 @@ final class CommandControllerTest extends TestCase
             ],
         );
 
+        $route = new Route(
+            path: '/api/news-articles/create-news-article-command',
+            options: $routeOptions,
+        );
+
         // -- Act
-        $controller->handle($request, $routePayload);
+        $controller->handle($request, $route);
     }
 }

--- a/tests/Controller/QueryControllerTest.php
+++ b/tests/Controller/QueryControllerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DigitalCraftsman\CQRS\Controller;
 
-use DigitalCraftsman\CQRS\DTO\Configuration;
 use DigitalCraftsman\CQRS\DTO\HandlerWrapperConfiguration;
+use DigitalCraftsman\CQRS\DTO\RouteConfiguration;
 use DigitalCraftsman\CQRS\DTOConstructor\SerializerDTOConstructor;
 use DigitalCraftsman\CQRS\RequestDecoder\JsonRequestDecoder;
 use DigitalCraftsman\CQRS\ResponseConstructor\SerializerJsonResponseConstructor;
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
@@ -111,7 +112,7 @@ final class QueryControllerTest extends TestCase
         ];
 
         $request = new Request(content: json_encode($content, JSON_THROW_ON_ERROR));
-        $routePayload = Configuration::routePayload(
+        $routeOptions = RouteConfiguration::routeOptions(
             dtoClass: GetTasksQuery::class,
             handlerClass: GetTasksQueryHandler::class,
             dtoDataTransformerClasses: [
@@ -125,8 +126,13 @@ final class QueryControllerTest extends TestCase
             ],
         );
 
+        $route = new Route(
+            path: '/api/tasks/get-tasks-query',
+            options: $routeOptions,
+        );
+
         // -- Act
-        $response = $controller->handle($request, $routePayload);
+        $response = $controller->handle($request, $route);
 
         // -- Assert
         /** @var string $body */
@@ -203,7 +209,7 @@ final class QueryControllerTest extends TestCase
         ];
 
         $request = new Request(content: json_encode($content, JSON_THROW_ON_ERROR));
-        $routePayload = Configuration::routePayload(
+        $routeOptions = RouteConfiguration::routeOptions(
             dtoClass: GetTasksQuery::class,
             handlerClass: FailingGetTasksQueryHandler::class,
             dtoDataTransformerClasses: [
@@ -217,7 +223,12 @@ final class QueryControllerTest extends TestCase
             ],
         );
 
+        $route = new Route(
+            path: '/api/tasks/get-tasks-query',
+            options: $routeOptions,
+        );
+
         // -- Act
-        $controller->handle($request, $routePayload);
+        $controller->handle($request, $route);
     }
 }


### PR DESCRIPTION
## Changes

- Instead of using `defaults()` of the route, we're now using `options()` which is more appropriate to configure a route.

## Review

- [ ] Validate with existing application.

## Release

Needs new minor release due to breaking change.

Resolves #17 