### PR TITLE
Remove serializer context configuration and update components

### DIFF
--- a/.docker/php-8.2/Dockerfile
+++ b/.docker/php-8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.0RC4-fpm-alpine3.16
+FROM php:8.2.0RC6-fpm-alpine3.16
 
 RUN apk add --update \
     autoconf \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - **[Breaking change](./UPGRADE.md#renamed-configuration-to-routepayload-and-converted-to-a-value-object)**: Renamed `Configuration` to `RoutePayload` and converted to a value object
 - **[Breaking change](./UPGRADE.md#new-method-for-requestvalidatorinterface-requestdatatransformerinterface-dtovalidatorinterface-and-handlerwrapperinterface)**: Added `areParametersValid` method to `RequestValidatorInterface`, `RequestDataTransformerInterface`, `DTOValidatorInterface` and `HandlerWrapperInterface`
 - **[Breaking change](./UPGRADE.md#update-handler-wrapper-configuration)**: Replaced `HandlerWrapperConfiguration` with simple map configuration.
+- **[Breaking change](./UPGRADE.md#removed-serializer_context-configuration)**: Removed `serializer_context` configuration. It was identical with the one that can be defined in the Symfony framework configuration.
 - **Breaking change**: Added the parameters `requestValidatorClassesToMergeWithDefault`, `requestDataTransformerClassesToMergeWithDefault`, `dtoValidatorClassesToMergeWithDefault` or `handlerWrapperClassesToMergeWithDefault` to `RoutePayload`. This change is only breaking when you don't use named parameters in your routing (which is highly recommended). Using those parameters instead the version without `*ToMergeWithDefault` merges the configuration with the default instead of replacing it ([see routing docs](./docs/routing.md#merge-configuration-from-request-validators-request-data-transformers-dto-validators-and-handler-wrappers-with-default)).
-- **Breaking change**: Removed `serializer_context` configuration. It was identical with the one that can be defined in the Symfony framework configuration.
 - Enabled usage of parameters in route configuration for request validators, request data transformers and DTO validators.
 - Enabled usage of parameters in default configuration for request validators, request data transformers, DTO validators and handler wrappers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **[Breaking change](./UPGRADE.md#new-method-for-requestvalidatorinterface-requestdatatransformerinterface-dtovalidatorinterface-and-handlerwrapperinterface)**: Added `areParametersValid` method to `RequestValidatorInterface`, `RequestDataTransformerInterface`, `DTOValidatorInterface` and `HandlerWrapperInterface`
 - **[Breaking change](./UPGRADE.md#update-handler-wrapper-configuration)**: Replaced `HandlerWrapperConfiguration` with simple map configuration.
 - **Breaking change**: Added the parameters `requestValidatorClassesToMergeWithDefault`, `requestDataTransformerClassesToMergeWithDefault`, `dtoValidatorClassesToMergeWithDefault` or `handlerWrapperClassesToMergeWithDefault` to `RoutePayload`. This change is only breaking when you don't use named parameters in your routing (which is highly recommended). Using those parameters instead the version without `*ToMergeWithDefault` merges the configuration with the default instead of replacing it ([see routing docs](./docs/routing.md#merge-configuration-from-request-validators-request-data-transformers-dto-validators-and-handler-wrappers-with-default)).
+- **Breaking change**: Removed `serializer_context` configuration. It was identical with the one that can be defined in the Symfony framework configuration.
 - Enabled usage of parameters in route configuration for request validators, request data transformers and DTO validators.
 - Enabled usage of parameters in default configuration for request validators, request data transformers, DTO validators and handler wrappers.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -132,6 +132,21 @@ return static function (CqrsConfig $cqrsConfig) {
         ]);
 ```
 
+### Removed `serializer_context` configuration
+
+It was identical with the one that can be defined in the Symfony framework configuration.
+
+Remove it from the CQRS configuration and move your context into the `framework.yaml`.
+
+```yaml
+framework:
+  serializer:
+    default_context:
+      # Your context, for example:
+      skip_null_values: true
+      preserve_empty_objects: true
+```
+
 ## From 0.6.* to 0.7.0
 
 ### Upgrade to at least PHP 8.1

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "symfony/serializer": "^5.4|^6.0"
   },
   "require-dev": {
-    "digital-craftsman/ids": "0.4.*",
+    "digital-craftsman/ids": "0.5.*",
     "friendsofphp/php-cs-fixer": "^3.3",
     "phpunit/phpunit": "^9.5",
     "symfony/property-info": "^6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -3118,16 +3118,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.12.0",
+            "version": "v3.13.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "eae11d945e2885d86e1c080eec1bb30a2aa27998"
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "a6232229a8309e8811dc751c28b91cb34b2943e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/eae11d945e2885d86e1c080eec1bb30a2aa27998",
-                "reference": "eae11d945e2885d86e1c080eec1bb30a2aa27998",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a6232229a8309e8811dc751c28b91cb34b2943e1",
+                "reference": "a6232229a8309e8811dc751c28b91cb34b2943e1",
                 "shasum": ""
             },
             "require": {
@@ -3151,7 +3151,7 @@
             },
             "require-dev": {
                 "justinrainbow/json-schema": "^5.2",
-                "keradus/cli-executor": "^1.5",
+                "keradus/cli-executor": "^2.0",
                 "mikey179/vfsstream": "^1.6.10",
                 "php-coveralls/php-coveralls": "^2.5.2",
                 "php-cs-fixer/accessible-object": "^1.1",
@@ -3194,8 +3194,8 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "support": {
-                "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.12.0"
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.13.0"
             },
             "funding": [
                 {
@@ -3203,7 +3203,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-12T14:20:51+00:00"
+            "time": "2022-10-31T19:28:50+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -6079,16 +6079,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.29.0",
+            "version": "4.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3"
+                "reference": "d0bc6e25d89f649e4f36a534f330f8bb4643dd69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3",
-                "reference": "7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d0bc6e25d89f649e4f36a534f330f8bb4643dd69",
+                "reference": "d0bc6e25d89f649e4f36a534f330f8bb4643dd69",
                 "shasum": ""
             },
             "require": {
@@ -6181,9 +6181,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.29.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.30.0"
             },
-            "time": "2022-10-11T17:09:17+00:00"
+            "time": "2022-11-06T20:37:08+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fce04178f36eff765a10a0fbd8ecdce",
+    "content-hash": "c3ef7a9661e0b904201ec45b08caf473",
     "packages": [
         {
             "name": "psr/cache",
@@ -2370,16 +2370,16 @@
         },
         {
             "name": "digital-craftsman/ids",
-            "version": "v0.4.0",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/digital-craftsman-de/ids.git",
-                "reference": "7ac914a46dcbcf66b2e60b1aa4ac01769328fc11"
+                "reference": "a1079e0967e168897a0d90afded9a7e211dbbd35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/digital-craftsman-de/ids/zipball/7ac914a46dcbcf66b2e60b1aa4ac01769328fc11",
-                "reference": "7ac914a46dcbcf66b2e60b1aa4ac01769328fc11",
+                "url": "https://api.github.com/repos/digital-craftsman-de/ids/zipball/a1079e0967e168897a0d90afded9a7e211dbbd35",
+                "reference": "a1079e0967e168897a0d90afded9a7e211dbbd35",
                 "shasum": ""
             },
             "require": {
@@ -2391,6 +2391,8 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.3",
+                "infection/infection": "^0.26.15",
+                "phpstan/phpstan": "^1.9",
                 "phpunit/phpunit": "^9.5",
                 "vimeo/psalm": "^4.12"
             },
@@ -2416,9 +2418,9 @@
             "description": "Working with value objects for ids in Symfony",
             "support": {
                 "issues": "https://github.com/digital-craftsman-de/ids/issues",
-                "source": "https://github.com/digital-craftsman-de/ids/tree/v0.4.0"
+                "source": "https://github.com/digital-craftsman-de/ids/tree/v0.5.1"
             },
-            "time": "2022-10-16T13:51:47+00:00"
+            "time": "2022-11-21T09:57:21+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,14 +44,6 @@ return static function (CqrsConfig $cqrsConfig) {
             ConnectionTransactionWrapper::class => null,
         ])
         ->defaultResponseConstructorClass(EmptyJsonResponseConstructor::class);
-
-    // -- Serializer
-
-    // See https://symfony.com/doc/current/components/serializer.html#option-2-using-the-context
-    $cqrsConfig->serializerContext([
-        AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
-        AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,
-    ]);
 };
 ```
 
@@ -115,10 +107,4 @@ cqrs:
     
     # Class of the default response constructor of query controller when there is none defined for the route
     default_response_constructor_class: 'DigitalCraftsman\CQRS\ResponseConstructor\SerializerJsonResponseConstructor'
-
-  # Define the context that will be used by the JSON serializer
-  # See https://symfony.com/doc/current/components/serializer.html#option-2-using-the-context
-  serializer_context:
-    skip_null_values: true
-    preserve_empty_objects: true
 ```

--- a/src/DependencyInjection/CQRSExtension.php
+++ b/src/DependencyInjection/CQRSExtension.php
@@ -84,7 +84,6 @@ final class CQRSExtension extends Extension
          *     default_handler_wrapper_classes: array<class-string<HandlerWrapperInterface>, scalar|array<array-key, scalar|null>|null>|null,
          *     default_response_constructor_class: string|null,
          *   },
-         *   serializer_context: array,
          * } $config
          */
         $config = $this->processConfiguration($configuration, $configs);
@@ -136,7 +135,5 @@ final class CQRSExtension extends Extension
         foreach ($config['command_controller'] as $key => $value) {
             $container->setParameter('cqrs.command_controller.'.$key, $value);
         }
-
-        $container->setParameter('cqrs.serializer_context', $config['serializer_context']);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -80,11 +80,6 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('default_response_constructor_class')->defaultNull()->end()
                     ->end()
                 ->end()
-                ->arrayNode('serializer_context')
-                    ->beforeNormalization()->castToArray()->end()
-                    ->defaultValue([])
-                    ->prototype('scalar')->end()
-                ->end()
             ->end()
         ;
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -26,8 +26,6 @@ services:
   DigitalCraftsman\CQRS\ResponseConstructor\SerializerJsonResponseConstructor:
     autowire: true
     autoconfigure: true
-    arguments:
-      $serializerContext: '%cqrs.serializer_context%'
     tags: [ 'cqrs.response_constructor' ]
 
   DigitalCraftsman\CQRS\ResponseConstructor\StreamedResponseConstructor:

--- a/src/ResponseConstructor/SerializerJsonResponseConstructor.php
+++ b/src/ResponseConstructor/SerializerJsonResponseConstructor.php
@@ -15,13 +15,12 @@ final class SerializerJsonResponseConstructor implements ResponseConstructorInte
     /** @codeCoverageIgnore */
     public function __construct(
         private readonly SerializerInterface $serializer,
-        private readonly array $serializerContext,
     ) {
     }
 
     public function constructResponse($data, Request $request): JsonResponse
     {
-        $content = $this->serializer->serialize($data, JsonEncoder::FORMAT, $this->serializerContext);
+        $content = $this->serializer->serialize($data, JsonEncoder::FORMAT);
 
         return new JsonResponse($content, Response::HTTP_OK, [], true);
     }

--- a/tests/Controller/QueryControllerTest.php
+++ b/tests/Controller/QueryControllerTest.php
@@ -100,7 +100,7 @@ final class QueryControllerTest extends TestCase
                     new GetTasksQueryHandler($tasksInMemoryRepository),
                 ],
                 responseConstructors: [
-                    new SerializerJsonResponseConstructor($serializer, []),
+                    new SerializerJsonResponseConstructor($serializer),
                 ],
             ),
             [],
@@ -197,7 +197,7 @@ final class QueryControllerTest extends TestCase
                     new FailingGetTasksQueryHandler(),
                 ],
                 responseConstructors: [
-                    new SerializerJsonResponseConstructor($serializer, []),
+                    new SerializerJsonResponseConstructor($serializer),
                 ],
             ),
             [],

--- a/tests/DependencyInjection/CQRSExtensionTest.php
+++ b/tests/DependencyInjection/CQRSExtensionTest.php
@@ -56,8 +56,5 @@ final class CQRSExtensionTest extends TestCase
         /** @psalm-suppress PossiblyInvalidArgument */
         self::assertCount(0, $container->getParameter('cqrs.command_controller.default_handler_wrapper_classes'));
         self::assertNull($container->getParameter('cqrs.command_controller.default_response_constructor_class'));
-
-        /** @psalm-suppress PossiblyInvalidArgument */
-        self::assertCount(0, $container->getParameter('cqrs.serializer_context'));
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -58,10 +58,6 @@ final class ConfigurationTest extends TestCase
                     ],
                     'default_response_constructor_class' => SerializerJsonResponseConstructor::class,
                 ],
-                'serializer_context' => [
-                    'skip_null_values' => true,
-                    'preserve_empty_objects' => true,
-                ],
             ],
         ];
 
@@ -104,9 +100,5 @@ final class ConfigurationTest extends TestCase
             SerializerJsonResponseConstructor::class,
             $config['query_controller']['default_response_constructor_class'],
         );
-
-        // Serializer context
-        self::assertTrue($config['serializer_context']['skip_null_values']);
-        self::assertTrue($config['serializer_context']['preserve_empty_objects']);
     }
 }

--- a/tests/ResponseConstructor/SerializerJsonResponseConstructorTest.php
+++ b/tests/ResponseConstructor/SerializerJsonResponseConstructorTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
@@ -26,10 +25,6 @@ final class SerializerJsonResponseConstructorTest extends TestCase
         // -- Arrange
         $serializerJsonResponseConstructor = new SerializerJsonResponseConstructor(
             new Serializer([new PropertyNormalizer()], [new JsonEncoder()]),
-            [
-                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
-                AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,
-            ],
         );
 
         $userReadModel = new UserReadModel(


### PR DESCRIPTION
## Changes

- Removed serializer context configuration. It turns out it's no different from simply configuring the serializer context as part of the Symfony framework configuration.
- PHP 8.2 Docker image was updated to RC6.
- Updated dev dependencies.

Resolves #30 