### PR TITLE
Use shields.io for badges in README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,21 +25,21 @@ help: Makefile
 ## build				Build the Docker images.
 .PHONY: build
 build:
-	docker-compose build
+	docker compose build
 
 ## up				Start the Docker stack.
 .PHONY: up
 up: .up
 
 .up:
-	docker-compose up -d
+	docker compose up -d
 
 ## down				Stop the Docker stack.
 .PHONY: down
 down: .down
 
 .down:
-	docker-compose down
+	docker compose down
 
 ## update				Rebuild Docker images and start stack.
 .PHONY: update
@@ -59,12 +59,12 @@ install: install-8.3
 ## install-8.2			Install PHP dependencies with PHP 8.2.
 .PHONY: install-8.2
 install-8.2:
-	docker-compose run --rm php-8.2 composer install
+	docker compose run --rm php-8.2 composer install
 
 ## install-8.3			Install PHP dependencies with PHP 8.3.
 .PHONY: install-8.3
 install-8.3:
-	docker-compose run --rm php-8.3 composer install
+	docker compose run --rm php-8.3 composer install
 
 ## php-cli			Enter a shell for the default PHP version (8.2).
 .PHONY: php-cli
@@ -73,12 +73,12 @@ php-cli: php-8.3-cli
 ## php-8.2-cli			Enter a shell for PHP 8.2.
 .PHONY: php-8.2-cli
 php-8.2-cli:
-	docker-compose run --rm php-8.2 sh
+	docker compose run --rm php-8.2 sh
 
 ## php-8.3-cli			Enter a shell for PHP 8.3.
 .PHONY: php-8.3-cli
 php-8.3-cli:
-	docker-compose run --rm php-8.3 sh
+	docker compose run --rm php-8.3 sh
 
 ##
 ## Tests and code validation
@@ -96,28 +96,28 @@ php-tests: php-8.2-tests php-8.3-tests
 ## php-8.2-tests			Run tests with PHP 8.2.
 .PHONY: php-8.2-tests
 php-8.2-tests:
-	docker-compose run --rm php-8.2 ./vendor/bin/phpunit
+	docker compose run --rm php-8.2 ./vendor/bin/phpunit
 
 ## php-8.3-tests			Run tests with PHP 8.3.
 .PHONY: php-8.3-tests
 php-8.3-tests:
-	docker-compose run --rm php-8.3 ./vendor/bin/phpunit
+	docker compose run --rm php-8.3 ./vendor/bin/phpunit
 
 ## php-8.2-tests-html-coverage	Run the tests with PHP 8.2 including coverage report as HTML.
 .PHONY: php-8.2-tests-html-coverage
 php-8.2-tests-html-coverage:
-	docker-compose run --rm php-8.2 ./vendor/bin/phpunit --coverage-html ./coverage
+	docker compose run --rm php-8.2 ./vendor/bin/phpunit --coverage-html ./coverage
 
 ## php-8.3-tests-html-coverage	Run the tests with PHP 8.3 including coverage report as HTML.
 .PHONY: php-8.3-tests-html-coverage
 php-8.3-tests-html-coverage:
-	docker-compose run --rm php-8.3 ./vendor/bin/phpunit --coverage-html ./coverage
+	docker compose run --rm php-8.3 ./vendor/bin/phpunit --coverage-html ./coverage
 
 ## php-code-validation		Run code fixers and linters with default PHP version (8.2).
 .PHONY: php-code-validation
 php-code-validation:
-	docker-compose run --rm php-8.3 ./vendor/bin/php-cs-fixer fix
-	docker-compose run --rm php-8.3 ./vendor/bin/psalm --show-info=false --no-diff
+	docker compose run --rm php-8.3 ./vendor/bin/php-cs-fixer fix
+	docker compose run --rm php-8.3 ./vendor/bin/psalm --show-info=false --no-diff
 
 ##
 ## CI
@@ -127,9 +127,9 @@ php-code-validation:
 ## php-8.2-tests-ci		Run the tests for PHP 8.2 for CI.
 .PHONY: php-8.2-tests-ci
 php-8.2-tests-ci:
-	docker-compose run --rm php-8.2 ./vendor/bin/phpunit
+	docker compose run --rm php-8.2 ./vendor/bin/phpunit
 
 ## php-8.3-tests-ci		Run the tests for PHP 8.3 for CI.
 .PHONY: php-8.3-tests-ci
 php-8.3-tests-ci:
-	docker-compose run --rm php-8.3 ./vendor/bin/phpunit --coverage-clover ./coverage.xml
+	docker compose run --rm php-8.3 ./vendor/bin/phpunit --coverage-clover ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Reduced cost of change through CQRS in Symfony
 
-[![Latest Stable Version](http://poser.pugx.org/digital-craftsman/cqrs/v)](https://packagist.org/packages/digital-craftsman/cqrs)
-[![PHP Version Require](http://poser.pugx.org/digital-craftsman/cqrs/require/php)](https://packagist.org/packages/digital-craftsman/cqrs)
+[![Latest Stable Version](https://img.shields.io/badge/stable-0.13.2-blue)](https://packagist.org/packages/digital-craftsman/cqrs)
+[![PHP Version Require](https://img.shields.io/badge/php-8.2|8.3-5b5d95)](https://packagist.org/packages/digital-craftsman/cqrs)
 [![codecov](https://codecov.io/gh/digital-craftsman-de/cqrs/branch/main/graph/badge.svg?token=YUKRDW1L8G)](https://codecov.io/gh/digital-craftsman-de/cqrs)
-[![Total Downloads](http://poser.pugx.org/digital-craftsman/cqrs/downloads)](https://packagist.org/packages/digital-craftsman/cqrs)
-[![License](http://poser.pugx.org/digital-craftsman/cqrs/license)](https://packagist.org/packages/digital-craftsman/cqrs)
+![Packagist Downloads](https://img.shields.io/packagist/dt/digital-craftsman/cqrs)
+![Packagist License](https://img.shields.io/packagist/l/digital-craftsman/cqrs)
 
 ## Installation and configuration
 


### PR DESCRIPTION
## Changes

- Use shields.io for badges in README.
- Switched old `docker-compose` commands to `docker compose`.